### PR TITLE
feat(jest): Make links support hosted Github

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -14,8 +14,8 @@ beforeEach(() => {
         head: {
           ref: "branch",
           repo: {
-            html_url: "https://github.com/user",
             full_name: "repo/slug",
+            html_url: "https://github.com/user",
             owner: {
               login: "user"
             }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -14,7 +14,11 @@ beforeEach(() => {
         head: {
           ref: "branch",
           repo: {
-            full_name: "repo/slug"
+            html_url: "https://github.com/user",
+            full_name: "repo/slug",
+            owner: {
+              login: "user"
+            }
           }
         }
       },
@@ -51,6 +55,30 @@ test("warns when test results JSON file cannot be read", () => {
     testResultsJsonPath: fixture("nonexistent.json")
   });
   expect(global["fail"]).toHaveBeenCalled();
+});
+
+test("can create links for github", () => {
+  jestResults({
+    testResultsJsonPath: fixture("failing-tests.json")
+  });
+  expect(global["fail"]).toHaveBeenCalledWith(
+    expect.stringMatching(
+      /https:\/\/github.com\/repo\/slug\/blob\/branch\/(.*)?\/file-utils.test.ts#L24/
+    )
+  );
+});
+
+test("can create links for hosted github", () => {
+  global["danger"].github.pr.head.repo.html_url =
+    "https://mydomain.github.com/user";
+  jestResults({
+    testResultsJsonPath: fixture("failing-tests.json")
+  });
+  expect(global["fail"]).toHaveBeenCalledWith(
+    expect.stringMatching(
+      /https:\/\/mydomain.github.com\/repo\/slug\/blob\/branch\/(.*)?\/file-utils.test.ts#L24/
+    )
+  );
 });
 
 test.skip("Fails 6", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,15 +75,13 @@ const presentErrorsForNewStyleResults = (jsonResults: IJestTestResults) => {
 // e.g. https://github.com/orta/danger-plugin-jest/blob/master/src/__tests__/fails.test.ts
 const linkToTest = (file: string, msg: string, title: string) => {
   const line = lineOfError(msg, file);
+  const githubRoot = danger.github.pr.head.repo.html_url.split(
+    danger.github.pr.head.repo.owner.login
+  )[0];
   const repo = danger.github.pr.head.repo;
-  const urlParts = [
-    "https://github.com",
-    repo.full_name,
-    "blob",
-    danger.github.pr.head.ref,
-    `${file}${"line" ? "#L" + line : ""}`
-  ];
-  return `<a href='${urlParts.join("/")}'>${title}</a>`;
+  const url = `${githubRoot}${repo.full_name}/blob/${danger.github.pr.head
+    .ref}/${file}${"line" ? "#L" + line : ""}`;
+  return `<a href='${url}'>${title}</a>`;
 };
 
 const assertionFailString = (


### PR DESCRIPTION
Previously, links generated by this plugin were hard-coded to github. This would lead to invalid
links when using a hosted version of GitHub. This changed mimics what the main danger file does to
read the URL from the GitHub repo and use that instead.