### PR TITLE
Extract test result reporter and add support bitbucket cloud.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ import jest from 'danger-plugin-jest'
 jest()
 // Custom path
 jest({ testResultsJsonPath: path.resolve(__dirname, 'tests/results.json') })
+
+// BitbucketCloud
+import jest, { BitbucketCloudReporter } from 'danger-plugin-jest'
+
+jest({ reporter: BitbucketCloudReporter })
 ```
 
 See [`src/index.ts`](https://github.com/macklinu/danger-plugin-jest/blob/master/src/index.ts) for more details.

--- a/src/ReporterHelper.ts
+++ b/src/ReporterHelper.ts
@@ -1,0 +1,27 @@
+import * as path from 'path'
+
+const ReporterHelper = {
+  lineOfError: (msg: string, filePath: string): number | null => {
+    const filename = path.basename(filePath)
+    const restOfTrace = msg.split(filename, 2)[1]
+    return restOfTrace ? parseInt(restOfTrace.split(':')[1], 10) : null
+  },
+  sanitizeShortErrorMessage: (msg: string): string => {
+    if (msg.includes('does not match stored snapshot')) {
+      return 'Snapshot has changed'
+    }
+
+    return msg
+      .split('   at', 1)[0]
+      .trim()
+      .split('\n')
+      .splice(2)
+      .join('')
+      .replace(/\s\s+/g, ' ')
+      .replace('Received:', ', received:')
+      .replace('., received', ', received')
+      .split('Difference:')[0]
+  },
+}
+
+export default ReporterHelper

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import * as fs from 'fs'
 
 import { IJestTestResults, ITestResultReporter } from './types'
 
-import GithubTestResultReporter from './reporters/GithubTestResultReporter'
+import GithubReporter from './reporters/GithubReporter'
+import BitbucketCloudReporter from './reporters/BitbucketCloudReporter'
 
 declare function fail(message?: string): void
 
@@ -12,11 +13,13 @@ export interface IPluginConfig {
   reporter?: ITestResultReporter
 }
 
+export { GithubReporter, BitbucketCloudReporter }
+
 export default function jest(config: Partial<IPluginConfig> = {}) {
   const {
     testResultsJsonPath = 'test-results.json',
     showSuccessMessage = false,
-    reporter = GithubTestResultReporter,
+    reporter = GithubReporter,
   } = config
   try {
     const jsonFileContents = fs.readFileSync(testResultsJsonPath, 'utf8')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,41 +1,36 @@
 import * as fs from 'fs'
-import * as path from 'path'
 
-import * as stripANSI from 'strip-ansi'
+import { IJestTestResults, ITestResultReporter } from './types'
 
-import { DangerDSLType } from '../node_modules/danger/distribution/dsl/DangerDSL'
-import {
-  IInsideFileTestResults,
-  IJestTestOldResults,
-  IJestTestResults,
-} from './types'
-declare var danger: DangerDSLType
+import GithubTestResultReporter from './reporters/GithubTestResultReporter'
+
 declare function fail(message?: string): void
-declare function message(message?: string): void
 
 export interface IPluginConfig {
   testResultsJsonPath: string
   showSuccessMessage: boolean
+  reporter?: ITestResultReporter
 }
 
 export default function jest(config: Partial<IPluginConfig> = {}) {
   const {
     testResultsJsonPath = 'test-results.json',
     showSuccessMessage = false,
+    reporter = GithubTestResultReporter,
   } = config
   try {
     const jsonFileContents = fs.readFileSync(testResultsJsonPath, 'utf8')
     const jsonResults: IJestTestResults = JSON.parse(jsonFileContents)
     if (jsonResults.success) {
-      jestSuccessFeedback(jsonResults, showSuccessMessage)
+      reporter.jestSuccessFeedback(jsonResults, showSuccessMessage)
       return
     }
 
     const isModernFormatResults = jsonResults.testResults[0].testResults
     if (isModernFormatResults) {
-      presentErrorsForNewStyleResults(jsonResults)
+      reporter.presentErrorsForNewStyleResults(jsonResults)
     } else {
-      presentErrorsForOldStyleResults(jsonResults as any)
+      reporter.presentErrorsForOldStyleResults(jsonResults as any)
     }
   } catch (e) {
     // tslint:disable-next-line:no-console
@@ -44,118 +39,4 @@ export default function jest(config: Partial<IPluginConfig> = {}) {
       '[danger-plugin-jest] Could not read test results. Danger cannot pass or fail the build.'
     )
   }
-}
-
-const jestSuccessFeedback = (
-  jsonResults: IJestTestResults,
-  showSuccessMessage: boolean
-): void => {
-  if (!showSuccessMessage) {
-    // tslint:disable-next-line:no-console
-    console.log(':+1: Jest tests passed')
-  } else {
-    message(
-      `:+1: Jest tests passed: ${jsonResults.numPassedTests}/${jsonResults.numTotalTests} (${jsonResults.numPendingTests} skipped)`
-    )
-  }
-}
-
-const presentErrorsForOldStyleResults = (jsonResults: IJestTestOldResults) => {
-  const failing = jsonResults.testResults.filter(tr => tr.status === 'failed')
-
-  failing.forEach(results => {
-    const relativeFilePath = path.relative(process.cwd(), results.name)
-    const failedAssertions = results.assertionResults.filter(
-      r => r.status === 'failed'
-    )
-    const failMessage = fileToFailString(
-      relativeFilePath,
-      failedAssertions as any
-    )
-    fail(failMessage)
-  })
-}
-
-const presentErrorsForNewStyleResults = (jsonResults: IJestTestResults) => {
-  const failing = jsonResults.testResults.filter(tr => tr.numFailingTests > 0)
-
-  failing.forEach(results => {
-    const relativeFilePath = path.relative(process.cwd(), results.testFilePath)
-    const failedAssertions = results.testResults.filter(
-      r => r.status === 'failed'
-    )
-    const failMessage = fileToFailString(relativeFilePath, failedAssertions)
-    fail(failMessage)
-  })
-}
-
-// e.g. https://github.com/orta/danger-plugin-jest/blob/master/src/__tests__/fails.test.ts
-const linkToTest = (file: string, msg: string, title: string) => {
-  const line = lineOfError(msg, file)
-  const githubRoot = danger.github.pr.head.repo.html_url.split(
-    danger.github.pr.head.repo.owner.login
-  )[0]
-  const repo = danger.github.pr.head.repo
-  const url = `${githubRoot}${repo.full_name}/blob/${
-    danger.github.pr.head.ref
-  }/${file}${line ? `#L${line}` : ''}`
-  return `<a href='${url}'>${title}</a>`
-}
-
-const assertionFailString = (
-  file: string,
-  status: IInsideFileTestResults
-): string => `
-<li>
-${linkToTest(
-  file,
-  status.failureMessages && status.failureMessages[0],
-  status.title
-)}
-<br/>
-${sanitizeShortErrorMessage(
-  status.failureMessages && stripANSI(status.failureMessages[0])
-)}
-
-<details>
-<summary>Full message</summary>
-<pre><code>
-${status.failureMessages && stripANSI(status.failureMessages.join('\n'))}
-</code></pre>
-</details>
-</li>
-<br/>
-`
-
-const fileToFailString = (
-  // tslint:disable-next-line:no-shadowed-variable
-  path: string,
-  failedAssertions: IInsideFileTestResults[]
-): string => `
-<b>🃏 FAIL</b> in ${danger.github.utils.fileLinks([path])}
-
-${failedAssertions.map(a => assertionFailString(path, a)).join('\n\n')}
-`
-
-const lineOfError = (msg: string, filePath: string): number | null => {
-  const filename = path.basename(filePath)
-  const restOfTrace = msg.split(filename, 2)[1]
-  return restOfTrace ? parseInt(restOfTrace.split(':')[1], 10) : null
-}
-
-const sanitizeShortErrorMessage = (msg: string): string => {
-  if (msg.includes('does not match stored snapshot')) {
-    return 'Snapshot has changed'
-  }
-
-  return msg
-    .split('   at', 1)[0]
-    .trim()
-    .split('\n')
-    .splice(2)
-    .join('')
-    .replace(/\s\s+/g, ' ')
-    .replace('Received:', ', received:')
-    .replace('., received', ', received')
-    .split('Difference:')[0]
 }

--- a/src/reporters/BitbucketCloudReporter.ts
+++ b/src/reporters/BitbucketCloudReporter.ts
@@ -11,6 +11,8 @@ import * as stripANSI from 'strip-ansi'
 import ReporterHelper from '../ReporterHelper'
 
 declare var danger: DangerDSLType
+declare function fail(message?: string): void
+declare function message(message?: string): void
 declare function markdown(message?: string): void
 
 const BitbucketCloudReporter: ITestResultReporter = {
@@ -72,18 +74,11 @@ const initialFailingMessage = () => {
 
 const linkToTest = (file: string, msg: string, title: string) => {
   var line = ReporterHelper.lineOfError(msg, file)
-  return (
-    'Case: [' +
-    title +
-    '](https://bitbucket.org/' +
-    danger.bitbucket_cloud.pr.source.repository.full_name +
-    '/src/' +
-    danger.bitbucket_cloud.pr.source.commit.hash +
-    '/' +
-    file +
-    (line ? '#lines-' + line : '') +
-    ')'
-  )
+  return `Case: [${title}](https://bitbucket.org/${
+    danger.bitbucket_cloud.pr.source.repository.full_name
+  }/src/${danger.bitbucket_cloud.pr.source.commit.hash}/${file}${
+    line ? `#lines-${line}` : ''
+  })`
 }
 
 const assertionFailString = (

--- a/src/reporters/BitbucketCloudReporter.ts
+++ b/src/reporters/BitbucketCloudReporter.ts
@@ -1,0 +1,125 @@
+import {
+  ITestResultReporter,
+  IJestTestOldResults,
+  IJestTestResults,
+  IInsideFileTestResults,
+} from '../types'
+
+import { DangerDSLType } from '../../node_modules/danger/distribution/dsl/DangerDSL'
+import * as path from 'path'
+import * as stripANSI from 'strip-ansi'
+import ReporterHelper from '../ReporterHelper'
+
+declare var danger: DangerDSLType
+declare function markdown(message?: string): void
+
+const BitbucketCloudReporter: ITestResultReporter = {
+  jestSuccessFeedback: (
+    jsonResults: IJestTestResults,
+    showSuccessMessage: boolean
+  ) => {
+    if (!showSuccessMessage) {
+      // tslint:disable-next-line:no-console
+      console.log(':+1: Jest tests passed')
+    } else {
+      message(
+        `:+1: Jest tests passed: ${jsonResults.numPassedTests}/${jsonResults.numTotalTests} (${jsonResults.numPendingTests} skipped)`
+      )
+    }
+  },
+  presentErrorsForOldStyleResults: (jsonResults: IJestTestOldResults) => {
+    initialFailingMessage()
+    const failing = jsonResults.testResults.filter(tr => tr.status === 'failed')
+
+    failing.forEach(results => {
+      var relativeFilePath = path.relative(process.cwd(), results.name)
+      var failedAssertions = results.assertionResults.filter(
+        r => r.status === 'failed'
+      )
+      var failMessage = fileToFailString(
+        relativeFilePath,
+        failedAssertions as any
+      )
+      markdown(failMessage)
+    })
+  },
+  presentErrorsForNewStyleResults: (jsonResults: IJestTestResults) => {
+    initialFailingMessage()
+    const failing = jsonResults.testResults.filter(tr => tr.numFailingTests > 0)
+
+    failing.forEach(results => {
+      var relativeFilePath = path.relative(process.cwd(), results.testFilePath)
+      var failedAssertions = results.testResults.filter(
+        r => r.status === 'failed'
+      )
+      var failMessage = fileToFailString(relativeFilePath, failedAssertions)
+      markdown(failMessage)
+    })
+  },
+}
+
+const initialFailingMessage = () => {
+  fail('[danger-plugin-jest] Found some issues below.')
+  markdown(
+    `
+→
+
+#### ❗️[danger-plugin-jest] Error Messages ️❗️
+---
+`
+  )
+}
+
+const linkToTest = (file: string, msg: string, title: string) => {
+  var line = ReporterHelper.lineOfError(msg, file)
+  return (
+    'Case: [' +
+    title +
+    '](https://bitbucket.org/' +
+    danger.bitbucket_cloud.pr.source.repository.full_name +
+    '/src/' +
+    danger.bitbucket_cloud.pr.source.commit.hash +
+    '/' +
+    file +
+    (line ? '#lines-' + line : '') +
+    ')'
+  )
+}
+
+const assertionFailString = (
+  file: string,
+  status: IInsideFileTestResults
+): string => `
+  ${linkToTest(
+    file,
+    status.failureMessages && status.failureMessages[0],
+    status.title
+  )}
+
+
+  > ${ReporterHelper.sanitizeShortErrorMessage(
+    status.failureMessages && stripANSI(status.failureMessages[0])
+  )}
+
+
+  ##### Full message
+  \`\`\`
+  ${status.failureMessages && stripANSI(status.failureMessages.join('\n'))}
+  \`\`\`
+  `
+
+const fileToFailString = (
+  path: string,
+  failedAssertions: IInsideFileTestResults[]
+): string => `
+❌ **Fail** in \`${path}\`
+${failedAssertions
+  .map(function(a) {
+    return assertionFailString(path, a)
+  })
+  .join('\n\n')}
+---
+
+`
+
+export default BitbucketCloudReporter

--- a/src/reporters/GithubReporter.ts
+++ b/src/reporters/GithubReporter.ts
@@ -8,12 +8,13 @@ import {
 import { DangerDSLType } from '../../node_modules/danger/distribution/dsl/DangerDSL'
 import * as path from 'path'
 import * as stripANSI from 'strip-ansi'
+import ReporterHelper from '../ReporterHelper'
 
 declare var danger: DangerDSLType
 declare function fail(message?: string): void
 declare function message(message?: string): void
 
-const GithubTestResultReporter: ITestResultReporter = {
+const GithubReporter: ITestResultReporter = {
   jestSuccessFeedback: (
     jsonResults: IJestTestResults,
     showSuccessMessage: boolean
@@ -61,7 +62,7 @@ const GithubTestResultReporter: ITestResultReporter = {
 
 // e.g. https://github.com/orta/danger-plugin-jest/blob/master/src/__tests__/fails.test.ts
 const linkToTest = (file: string, msg: string, title: string) => {
-  const line = lineOfError(msg, file)
+  const line = ReporterHelper.lineOfError(msg, file)
   const githubRoot = danger.github.pr.head.repo.html_url.split(
     danger.github.pr.head.repo.owner.login
   )[0]
@@ -83,7 +84,7 @@ const assertionFailString = (
     status.title
   )}
   <br/>
-  ${sanitizeShortErrorMessage(
+  ${ReporterHelper.sanitizeShortErrorMessage(
     status.failureMessages && stripANSI(status.failureMessages[0])
   )}
   
@@ -107,27 +108,4 @@ const fileToFailString = (
   ${failedAssertions.map(a => assertionFailString(path, a)).join('\n\n')}
   `
 
-const lineOfError = (msg: string, filePath: string): number | null => {
-  const filename = path.basename(filePath)
-  const restOfTrace = msg.split(filename, 2)[1]
-  return restOfTrace ? parseInt(restOfTrace.split(':')[1], 10) : null
-}
-
-const sanitizeShortErrorMessage = (msg: string): string => {
-  if (msg.includes('does not match stored snapshot')) {
-    return 'Snapshot has changed'
-  }
-
-  return msg
-    .split('   at', 1)[0]
-    .trim()
-    .split('\n')
-    .splice(2)
-    .join('')
-    .replace(/\s\s+/g, ' ')
-    .replace('Received:', ', received:')
-    .replace('., received', ', received')
-    .split('Difference:')[0]
-}
-
-export default GithubTestResultReporter
+export default GithubReporter

--- a/src/reporters/GithubTestResultReporter.ts
+++ b/src/reporters/GithubTestResultReporter.ts
@@ -1,0 +1,133 @@
+import {
+  ITestResultReporter,
+  IJestTestResults,
+  IJestTestOldResults,
+  IInsideFileTestResults,
+} from '../types'
+
+import { DangerDSLType } from '../../node_modules/danger/distribution/dsl/DangerDSL'
+import * as path from 'path'
+import * as stripANSI from 'strip-ansi'
+
+declare var danger: DangerDSLType
+declare function fail(message?: string): void
+declare function message(message?: string): void
+
+const GithubTestResultReporter: ITestResultReporter = {
+  jestSuccessFeedback: (
+    jsonResults: IJestTestResults,
+    showSuccessMessage: boolean
+  ) => {
+    if (!showSuccessMessage) {
+      // tslint:disable-next-line:no-console
+      console.log(':+1: Jest tests passed')
+    } else {
+      message(
+        `:+1: Jest tests passed: ${jsonResults.numPassedTests}/${jsonResults.numTotalTests} (${jsonResults.numPendingTests} skipped)`
+      )
+    }
+  },
+  presentErrorsForOldStyleResults: (jsonResults: IJestTestOldResults) => {
+    const failing = jsonResults.testResults.filter(tr => tr.status === 'failed')
+
+    failing.forEach(results => {
+      const relativeFilePath = path.relative(process.cwd(), results.name)
+      const failedAssertions = results.assertionResults.filter(
+        r => r.status === 'failed'
+      )
+      const failMessage = fileToFailString(
+        relativeFilePath,
+        failedAssertions as any
+      )
+      fail(failMessage)
+    })
+  },
+  presentErrorsForNewStyleResults: (jsonResults: IJestTestResults) => {
+    const failing = jsonResults.testResults.filter(tr => tr.numFailingTests > 0)
+
+    failing.forEach(results => {
+      const relativeFilePath = path.relative(
+        process.cwd(),
+        results.testFilePath
+      )
+      const failedAssertions = results.testResults.filter(
+        r => r.status === 'failed'
+      )
+      const failMessage = fileToFailString(relativeFilePath, failedAssertions)
+      fail(failMessage)
+    })
+  },
+}
+
+// e.g. https://github.com/orta/danger-plugin-jest/blob/master/src/__tests__/fails.test.ts
+const linkToTest = (file: string, msg: string, title: string) => {
+  const line = lineOfError(msg, file)
+  const githubRoot = danger.github.pr.head.repo.html_url.split(
+    danger.github.pr.head.repo.owner.login
+  )[0]
+  const repo = danger.github.pr.head.repo
+  const url = `${githubRoot}${repo.full_name}/blob/${
+    danger.github.pr.head.ref
+  }/${file}${line ? `#L${line}` : ''}`
+  return `<a href='${url}'>${title}</a>`
+}
+
+const assertionFailString = (
+  file: string,
+  status: IInsideFileTestResults
+): string => `
+  <li>
+  ${linkToTest(
+    file,
+    status.failureMessages && status.failureMessages[0],
+    status.title
+  )}
+  <br/>
+  ${sanitizeShortErrorMessage(
+    status.failureMessages && stripANSI(status.failureMessages[0])
+  )}
+  
+  <details>
+  <summary>Full message</summary>
+  <pre><code>
+  ${status.failureMessages && stripANSI(status.failureMessages.join('\n'))}
+  </code></pre>
+  </details>
+  </li>
+  <br/>
+  `
+
+const fileToFailString = (
+  // tslint:disable-next-line:no-shadowed-variable
+  path: string,
+  failedAssertions: IInsideFileTestResults[]
+): string => `
+  <b>🃏 FAIL</b> in ${danger.github.utils.fileLinks([path])}
+  
+  ${failedAssertions.map(a => assertionFailString(path, a)).join('\n\n')}
+  `
+
+const lineOfError = (msg: string, filePath: string): number | null => {
+  const filename = path.basename(filePath)
+  const restOfTrace = msg.split(filename, 2)[1]
+  return restOfTrace ? parseInt(restOfTrace.split(':')[1], 10) : null
+}
+
+const sanitizeShortErrorMessage = (msg: string): string => {
+  if (msg.includes('does not match stored snapshot')) {
+    return 'Snapshot has changed'
+  }
+
+  return msg
+    .split('   at', 1)[0]
+    .trim()
+    .split('\n')
+    .splice(2)
+    .join('')
+    .replace(/\s\s+/g, ' ')
+    .replace('Received:', ', received:')
+    .replace('., received', ', received')
+    .split('Difference:')[0]
+}
+
+export default GithubTestResultReporter

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,3 +103,12 @@ export interface IJestTestOldResults {
   testResults: ITestResult[]
   wasInterrupted: boolean
 }
+
+export interface ITestResultReporter {
+  jestSuccessFeedback: (
+    jsonResults: IJestTestResults,
+    showSuccessMessage: boolean
+  ) => void
+  presentErrorsForOldStyleResults: (jsonResults: IJestTestOldResults) => void
+  presentErrorsForNewStyleResults: (jsonResults: IJestTestResults) => void
+}


### PR DESCRIPTION
- Extract reporter to interface `ITestResultReporter`, so we could use it to implement reporter for other platforms.
- Create `BitbucketCloudReporter` to support `BitbucketCloud`.

![BitbucketCloudReporter result](https://cdn1.imggmi.com/uploads/2019/10/3/2ed320afa05b440511cac1e365d357f1-full.png)